### PR TITLE
Dragging image causes redirect in Firefox

### DIFF
--- a/addon/mixins/droppable.js
+++ b/addon/mixins/droppable.js
@@ -107,6 +107,7 @@ var Droppable = Ember.Mixin.create({
     this._resetDroppability();
     // TODO: might not need this? I can't remember why its here
     event.stopPropagation();
+    event.preventDefault();
     return false;
   }.on('drop'),
 


### PR DESCRIPTION
For example:

```
{{#draggable-object content=user}}
  <img src="{{user.avatar}}">
{{/draggable-object}}
```

This works fine in Chrome, but in Firefox 35.0, causes the user to be redirected to the image when dropped.