### PR TITLE
Prevents Firefox from navigating to random numbers url on drop

### DIFF
--- a/addon/components/draggable-object-target.js
+++ b/addon/components/draggable-object-target.js
@@ -17,6 +17,8 @@ export default Ember.Component.extend(Droppable, {
 
   acceptDrop: function(event) {
     this.handleDrop(event);
+    //Firefox is navigating to a url on drop sometimes, this prevents that from happening
+    event.preventDefault();
   },
 
   actions: {


### PR DESCRIPTION
Added a prevent default, so some reason Firefox is trying to navigate to a random number url on drop.  I think it has something to do with the ghost image being dropped and Firefox trying to open it.  No idea.  Anyway, this fixes it and doesn't seem to prevent the plugin from breaking in my testing. On FF and Chrome latest.