### PR TITLE
fix deprecation in ember canary

### DIFF
--- a/app/templates/components/object-bin.hbs
+++ b/app/templates/components/object-bin.hbs
@@ -2,7 +2,7 @@
   <div class="object-bin-title">{{name}}</div>
   <br>
 
-  {{#each obj in model}}
+  {{#each model as |obj|}}
     {{#draggable-object content=obj action="handleObjectDragged"}}
       {{#with obj}}
         {{yield}}


### PR DESCRIPTION
DEPRECATION: Using the '{{#each item in model}}' form of the {{#each}} helper is deprecated. Please use the block param form instead ('{{#each model as |item|}}'). See http://emberjs.com/guides/deprecations/#toc_code-in-code-syntax-for-code-each-code for more details.