### PR TITLE
Updated object-bin.hbs to meet Ember 2.0 syntax

### DIFF
--- a/app/templates/components/object-bin.hbs
+++ b/app/templates/components/object-bin.hbs
@@ -2,7 +2,7 @@
   <div class="object-bin-title">{{name}}</div>
   <br>
 
-  {{#each obj in model}}
+  {{#each modal as |obj|}}
     {{#draggable-object content=obj action="handleObjectDragged"}}
       {{#with obj}}
         {{yield}}


### PR DESCRIPTION
I am attempting to update my application to Ember 2.0 and noticed that this addon was still using the old each helper syntax. 

Updated the each helper syntax in the object-bin component to remove the deprecation warning.