### PR TITLE
Prevents actions when the component is not draggable

### DIFF
--- a/addon/components/draggable-object.js
+++ b/addon/components/draggable-object.js
@@ -20,6 +20,10 @@ export default Ember.Component.extend({
   }),
 
   dragStart: function(event) {
+    if (!this.get('isDraggable')) {
+      event.preventDefault();
+      return;
+    }
 
     var dataTransfer = event.dataTransfer;
 
@@ -36,6 +40,10 @@ export default Ember.Component.extend({
   },
 
   dragEnd: function() {
+    if (!this.get('isDraggable')) {
+      return;
+    }
+
     var obj = this.get('content');
 
     if (obj) {
@@ -49,7 +57,7 @@ export default Ember.Component.extend({
     selectForDrag: function() {
       var obj = this.get('content');
       var hashId = this.get('coordinator').setObject(obj, { source: this });
-      this.get('coordinator').set("clickedId", hashId);
+      this.set('coordinator.clickedId', hashId);
     }
   }
 });

--- a/addon/components/draggable-object.js
+++ b/addon/components/draggable-object.js
@@ -40,7 +40,7 @@ export default Ember.Component.extend({
   },
 
   dragEnd: function() {
-    if (!this.get('isDraggable')) {
+    if (!this.get('isDraggingObject')) {
       return;
     }
 


### PR DESCRIPTION
The `dragStart` and `dragEnd` actions should not be called when `isDraggable === false`.
As an example, it occurs when the draggable component yields to a DOM tree that contains images.

This PR makes sure that even if the callbacks were called, they won't trigger any action.