### PR TITLE
Remove Ember 2.1 deprecation warning

### DIFF
--- a/app/initializers/coordinator-setup.js
+++ b/app/initializers/coordinator-setup.js
@@ -3,7 +3,8 @@ import Coordinator from '../models/coordinator';
 export default {
   name: "setup coordinator",
 
-  initialize: function(container,app) {
+  initialize: function() {
+    let app = arguments[1] || arguments[0];
     app.register("drag:coordinator",Coordinator);
     app.inject("component","coordinator","drag:coordinator");
   }


### PR DESCRIPTION
Updates the initializer to remove the deprecation warning in Ember 2.1 caused by having two arguments (container, app) in the initialize function. This uses the backwards compatible safe method described in the deprecation pages (http://emberjs.com/deprecations/v2.x/#toc_initializer-arity)