### PR TITLE
Rewritten drag coordinator

### DIFF
--- a/addon/services/drag-coordinator.js
+++ b/addon/services/drag-coordinator.js
@@ -2,20 +2,11 @@ import Ember from 'ember';
 
 export default Ember.Service.extend({
   arrayList: null,
-  newSortedList: Ember.computed('arrayList', function(){
-    //copy the passed in array so things aren't triggered while swapping items
-    var simpleArray = [];
-    this.get('arrayList').forEach(function(item){
-      simpleArray.push(item);
-    });
-    return simpleArray;
-  }),
   currentDragObject: null,
   currentDragEvent: null,
   currentDragItem: null,
-  currentOffsetItem: null,
-  isMoving: false,
   lastEvent: null,
+
   dragStarted: function(object, event, emberObject) {
     Ember.run.later(function(){
       Ember.$(event.target).css('opacity', '0.5');
@@ -30,55 +21,34 @@ export default Ember.Service.extend({
     this.set('currentDragObject', null);
     this.set('currentDragEvent', null);
     this.set('currentDragItem', null);
-    this.set('currentOffsetItem', null);
   },
   draggingOver: function(event, emberObject) {
-    var currentOffsetItem = this.get('currentOffsetItem');
-    var pos = this.relativeClientPosition(emberObject.$()[0], event);
-    var moveDirection = false;
-    if (!this.get('lastEvent')) {
-      this.set('lastEvent', event);
-    }
-    if (event.originalEvent.clientY < this.get('lastEvent').originalEvent.clientY) {
-      moveDirection = 'up';
-    }
-    if (event.originalEvent.clientY > this.get('lastEvent').originalEvent.clientY) {
-      moveDirection = 'down';
-    }
+    var currentDragItem = this.get('currentDragItem');
+    var isMoving = this.isMoving(emberObject.$()[0], event);
     this.set('lastEvent', event);
 
-    if (!this.get('isMoving')) {
-      if (event.target !== this.get('currentDragEvent').target) { //if not dragging over self
-        if (currentOffsetItem !== emberObject) {
-          if (pos.py > 0.33 && moveDirection === 'up' || pos.py > 0.33 && moveDirection === 'down') {
-            this.swapElements(emberObject);
-            this.set('currentOffsetItem', emberObject);
-          }
-        }
-      } else {
-        //reset because the node moved under the mouse with a swap
-        this.set('currentOffsetItem', null);
-      }
+    if (isMoving && emberObject.get('content') !== currentDragItem.get('content')) {
+      // Only if not dragging over self
+      this.insertElementOver(currentDragItem, emberObject);
     }
   },
-  swapNodes: function(a, b) {
-    var aparent = a.parentNode;
-    var asibling = a.nextSibling === b ? a : a.nextSibling;
-    b.parentNode.insertBefore(a, b);
-    aparent.insertBefore(b, asibling);
+  isMoving: function(el, event) {
+    var pos = this.relativeClientPosition(el, event);
+    var isMoving = false;
+    var lastEvent = this.get('lastEvent');
+
+    if (lastEvent && ((pos.px > 0.33 && event.originalEvent.clientX != lastEvent.originalEvent.clientX) ||
+      (pos.py > 0.33 && event.originalEvent.clientY != lastEvent.originalEvent.clientY))) {
+      isMoving = true;
+    }
+    return isMoving;
   },
-  swapObjectPositions: function(a, b) {
-    var newList = this.get('newSortedList');
-    var aPos = newList.indexOf(a);
-    var bPos = newList.indexOf(b);
-    newList[aPos] = b;
-    newList[bPos] = a;
-    this.set('newSortedList', newList);
-  },
-  swapElements: function(overElement) {
-    var draggingItem = this.get('currentDragItem');
-    this.swapNodes(draggingItem.$()[0], overElement.$()[0]);
-    this.swapObjectPositions(draggingItem.get('content'), overElement.get('content'));
+  insertElementOver: function(currentDragItem, overElement) {
+    var arrayList = this.get('arrayList');
+    var index = arrayList.indexOf(overElement.get('content'));
+    arrayList.removeObject(currentDragItem.get('content'));
+    arrayList.insertAt(index, currentDragItem.get('content'));
+    return;
   },
   relativeClientPosition: function (el, event) {
     var rect = el.getBoundingClientRect();
@@ -92,12 +62,6 @@ export default Ember.Service.extend({
     };
   },
   getChangedArray: function() {
-    //rebuild the passed in array
-    var arrayList = this.get('arrayList');
-    arrayList.clear();
-    this.get('newSortedList').forEach(function(item){
-      arrayList.addObject(item);
-    });
-    return arrayList;
+    return this.get('arrayList').toArray();
   }
 });


### PR DESCRIPTION
I have rewritten the drag coordinator. There were two problems I encountered with the original one. 

1. The DOM manipulation (by swapNodes) confused the Ember DOM view. This resulted in unexpected behaviour in the sorting. In this new version, the DOM manipulation is entirely done through Ember, since it simply modifies the list.
2. Grid based layouts were not supported because of the algorithm used: it swapped positions of the dragged over elements. This only works in linear sets such as lists. In this new version, it simply insert the element at the position of the dragged over element.

Please feel free to give me feedback if this commit is not according to your wishes. I now successfully use this version in a production app of a startup company. 