### PR TITLE
Fix Droppable class not extensible.

### DIFF
--- a/addon/mixins/droppable.js
+++ b/addon/mixins/droppable.js
@@ -161,9 +161,10 @@ var Droppable = Ember.Mixin.create({
 
 // Need to track this so we can determine `self-drop`.
 // It's on `Droppable` so we can test :\
-Droppable._currentDrag = null;
 window.addEventListener('dragstart', function(event) {
-  Droppable._currentDrag = event.target;
+  Droppable.reopenClass({
+    _currentDrag: event.target
+  });
 }, true);
 
 export default Droppable;


### PR DESCRIPTION
This fixes a fatal error occurring for me with Ember 2.3.0:
```
Uncaught TypeError: Cannot define property:_currentDrag, object is not extensible.
```

If you think we need to initialize this property to `null`, then we could instead use:
```js
Droppable.reopenClass({ _currentDrag: null });
```
