### PR TITLE
Allow to pass an `onClick` action that will be invoked with the original event.

### DIFF
--- a/addon/components/draggable-object-target.js
+++ b/addon/components/draggable-object-target.js
@@ -34,6 +34,13 @@ export default Ember.Component.extend(Droppable, {
     this.sendAction('dragOutAction');
   },
 
+  click(e) {
+    let onClick = this.get('onClick');
+    if (onClick) {
+      onClick(e.originalEvent);
+    }
+  },
+
   actions: {
     acceptForDrop: function() {
       var hashId = this.get('coordinator.clickedId');


### PR DESCRIPTION
Hi, thanks for this addon. Very helpful.

I found myself in a situation where my `draggable-object-target` are also clickable. I don't really want to play with wrapper divs because it's a table cell and styling divs inside table cells is pretty nightmarish. 

So, with this change, the `draggable-object-target` accepts an `onClick` action. If provided, it will be invoked when the area is clicked. If not provided, nothing happens, so It's totally backwards compatible.

```hbs
{{#draggable-object-target onClick=(action "selectCell")}}
  stuff
{{/draggable-object-target}}
```