### PR TITLE
Drag-drop should work even if sorting is off

### DIFF
--- a/addon/components/sortable-objects.js
+++ b/addon/components/sortable-objects.js
@@ -10,9 +10,8 @@ export default Ember.Component.extend( {
   enableSort: true,
   sortableObjectList: Ember.A(),
 
-  dragStart: function(event) {
+  dragStart: function() {
     if (!this.get('enableSort')) {
-      event.preventDefault();
       return;
     }
    if (!this.get('dragCoordinator.currentDragObject')) {

--- a/tests/integration/components/sortable-objects-test.js
+++ b/tests/integration/components/sortable-objects-test.js
@@ -133,6 +133,90 @@ test('sortable object renders draggable objects', function(assert) {
   });
 
 });
-//need to test to make sure sorting doesn't happen if off
+
+
+test('sorting does not happen if off', function(assert) {
+  const self = this;
+  let event = MockDataTransfer.makeMockEvent();
+  assert.expect(14);
+
+  this.set('pojoData', pojoData);
+
+  // sortEndAction should not be called
+  let sortEndActionCalled = false;
+  this.on('sortEndAction', function() {
+    sortEndActionCalled = true;
+  });
+
+  this.render(hbs`
+    {{#sortable-objects sortableObjectList=pojoData sortEndAction='sortEndAction' class='sortContainer' enableSort=false}}
+      {{#each pojoData as |item|}}
+        {{#draggable-object content=item overrideClass='sortObject' isSortable=false}}
+          {{item.title}}
+        {{/draggable-object}}
+      {{/each}}
+    {{/sortable-objects}}
+  `);
+
+  assert.equal(this.$('.sortObject').size(), 4);
+
+  let $component = this.$('.sortObject');
+  let $container = this.$('.sortContainer');
+
+  //Starts drag as usual
+  //set fake positions
+  event.originalEvent.clientX = 1;
+  event.originalEvent.clientY = 1;
+  Ember.run(function() {
+    triggerEvent($component, 'dragstart', event);
+  });
+  andThen(function() {
+    assert.equal($component.hasClass('is-dragging-object'), true);
+    //item is faded while dragging
+    assert.equal($component.css('opacity'), '0.5');
+  });
+
+  Ember.run(function() {
+    let event = MockDataTransfer.makeMockEvent();
+    event.originalEvent.clientX = 1;
+    event.originalEvent.clientY = 500;
+    triggerEvent($component.get(1), 'dragover', event);
+  });
+  Ember.run(function() {
+    let event = MockDataTransfer.makeMockEvent();
+    event.originalEvent.clientX = 1;
+    event.originalEvent.clientY = 501;
+    triggerEvent($component.get(1), 'dragover', event);
+  });
+  andThen(function() {
+    //Drag over does not affect order
+    let $components = self.$('.sortObject');
+    assert.equal(self.$($components.get(0)).text().trim(), 'Number 1');
+    assert.equal(self.$($components.get(1)).text().trim(), 'Number 2');
+    assert.equal(self.$($components.get(2)).text().trim(), 'Number 3');
+    assert.equal(self.$($components.get(3)).text().trim(), 'Number 4');
+  });
+  Ember.run(function() {
+    triggerEvent($component, 'dragend', event);
+    triggerEvent($container, 'dragend', event);
+    triggerEvent($container, 'drop', event);
+  });
+  andThen(function() {
+    //Visual drag items are reset
+    assert.equal($component.hasClass('is-dragging-object'), false);
+    assert.equal($component.css('opacity'), '1');
+  });
+  andThen(function() {
+    //Items are still visually in the correct order after drag end
+    let $components = self.$('.sortObject');
+    assert.equal(self.$($components.get(0)).text().trim(), 'Number 1');
+    assert.equal(self.$($components.get(1)).text().trim(), 'Number 2');
+    assert.equal(self.$($components.get(2)).text().trim(), 'Number 3');
+    assert.equal(self.$($components.get(3)).text().trim(), 'Number 4');
+  });
+  andThen(function() {
+    assert.equal(sortEndActionCalled, false);
+  });
+});
 //need to test ember data objects
 


### PR DESCRIPTION
I believe, when sorting is off, we should not prevent the drag event from triggering, for example in case when sortable-objects component is combined with simple drag-drop