### PR TITLE
Include event in dragStart action

### DIFF
--- a/addon/components/draggable-object.js
+++ b/addon/components/draggable-object.js
@@ -70,7 +70,7 @@ export default Ember.Component.extend({
     }
     this.set('isDraggingObject', true);
     this.get('dragCoordinator').dragStarted(obj, event, this);
-    this.sendAction('dragStartAction', obj);
+    this.sendAction('dragStartAction', obj, event);
     if (this.get('isSortable')) {
       this.sendAction('draggingSortItem', obj);
     }


### PR DESCRIPTION
I ran into an issue where I needed to be able to set the dragImage on drag start, including the event on the start of the drag action is what was needed. I think this might be useful for other people, and is more in line with how Ember treats other browser actions it sends to components. 