### PR TITLE
Expose drag event

### DIFF
--- a/addon/components/draggable-object.js
+++ b/addon/components/draggable-object.js
@@ -94,6 +94,10 @@ export default Ember.Component.extend({
     }
   },
 
+  drag: function(event) {
+    this.sendAction('dragMoveAction', event);
+  },
+
   dragOver: function(event) {
    if (this.get('isSortable')) {
      this.get('dragCoordinator').draggingOver(event, this);

--- a/tests/integration/components/draggable-object-test.js
+++ b/tests/integration/components/draggable-object-test.js
@@ -37,13 +37,16 @@ test('draggable object renders', function(assert) {
 });
 
 test('Draggable Object is draggable', function(assert) {
-  assert.expect(2);
+  assert.expect(3);
 
   //let myObject = {'id':0, data: 'Test Data'};
   let event = MockDataTransfer.makeMockEvent();
 
+  this.on('dragMoveAction', function(event) {
+    assert.ok(event);
+  });
   this.render(hbs`
-    {{#draggable-object content=myObject class='draggable-object'}}
+    {{#draggable-object content=myObject class='draggable-object' dragMoveAction=(action "dragMoveAction")}}
       Hi
       <a class="js-dragHandle dragHandle"></a>
     {{/draggable-object}}
@@ -56,6 +59,10 @@ test('Draggable Object is draggable', function(assert) {
   });
 
   assert.equal($component.hasClass('is-dragging-object'), true);
+
+  Ember.run(function() {
+    triggerEvent($component, 'drag', event);
+  });
 
   Ember.run(function() {
     triggerEvent($component, 'dragend', event);


### PR DESCRIPTION
This simply sends an action while the user is dragging an object around the page.

I needed to do this for a project in order to get XY coordinates of the dragged object so I could implement custom re-ordering. In `draggable-object-target` there's a `handleDragOver` hook, but it doesn't fire when the dragging object goes over a child element in the target region. 