### PR TITLE
Send sortableObjectList to the sortEndAction

### DIFF
--- a/addon/components/sortable-objects.js
+++ b/addon/components/sortable-objects.js
@@ -35,7 +35,8 @@ export default Ember.Component.extend( {
 
   drop: function(event) {
     if (this.get('enableSort')) {
-      this.sendAction('sortEndAction', event);
+      var obj = this.get('sortableObjectList');
+      this.sendAction('sortEndAction', obj, event);
     }
   }
 });


### PR DESCRIPTION
This change sends the `event` and `sortableObjectList` to the `sortEndAction`.
