### PR TITLE
Throw real Errors instead of strings

### DIFF
--- a/addon/components/object-bin.js
+++ b/addon/components/object-bin.js
@@ -6,7 +6,7 @@ var removeOne = function(arr,obj) {
   var l2 = arr.get('length');
 
   if (l-1 !== l2) {
-    throw "bad length " + l + " " + l2;
+    throw new Error("bad length " + l + " " + l2);
   }
 };
 

--- a/app/models/obj-hash.js
+++ b/app/models/obj-hash.js
@@ -14,7 +14,7 @@ export default Ember.Object.extend({
   getObj: function(key) {
     var res = this.get('content')[key];
     if (!res) {
-      throw "no obj for key "+key;
+      throw new Error("no obj for key "+key);
     }
     return res;
   },


### PR DESCRIPTION
Throwing strings in JS is generally a bad practice, as they don't have any useful information for telemetry when something goes wrong. For instance, a thrown string doesn't have a `stack` property that can be examined to find out where the error came from.
