### PR TITLE
Added overridable drag start/end actions

### DIFF
--- a/addon/components/draggable-object.js
+++ b/addon/components/draggable-object.js
@@ -73,7 +73,16 @@ export default Ember.Component.extend({
       Ember.set(obj, 'isDraggingObject', true);
     }
     this.set('isDraggingObject', true);
-    this.get('dragCoordinator').dragStarted(obj, event, this);
+    if (!this.get('dragCoordinator.enableSort') && this.get('dragCoordinator.sortComponentController')) {
+      //disable drag if sorting is disabled this is not used for regular
+      event.preventDefault();
+      return;
+    } else {
+      Ember.run.later(()=> {
+        this.dragStartHook(event);
+      });
+      this.get('dragCoordinator').dragStarted(obj, event, this);
+    }
     this.sendAction('dragStartAction', obj, event);
     if (this.get('isSortable')) {
       this.sendAction('draggingSortItem', obj, event);
@@ -91,7 +100,8 @@ export default Ember.Component.extend({
       Ember.set(obj, 'isDraggingObject', false);
     }
     this.set('isDraggingObject', false);
-    this.get('dragCoordinator').dragEnded(event);
+    this.dragEndHook(event);
+    this.get('dragCoordinator').dragEnded();
     this.sendAction('dragEndAction', obj, event);
     if (this.get('dragHandle')) {
       this.set('dragReady', false);
@@ -107,6 +117,14 @@ export default Ember.Component.extend({
      this.get('dragCoordinator').draggingOver(event, this);
    }
     return false;
+  },
+
+  dragStartHook(event) {
+    Ember.$(event.target).css('opacity', '0.5');
+  },
+
+  dragEndHook(event) {
+    Ember.$(event.target).css('opacity', '1');
   },
 
   drop(event) {

--- a/addon/services/drag-coordinator.js
+++ b/addon/services/drag-coordinator.js
@@ -27,22 +27,13 @@ export default Ember.Service.extend({
   },
 
   dragStarted(object, event, emberObject) {
-    if (!this.get('enableSort') && this.get('sortComponentController')) {
-      //disable drag if sorting is disabled this is not used for regular
-      event.preventDefault();
-      return;
-    }
-    Ember.run.later(function() {
-      Ember.$(event.target).css('opacity', '0.5');
-    });
     this.set('currentDragObject', object);
     this.set('currentDragEvent', event);
     this.set('currentDragItem', emberObject);
     event.dataTransfer.effectAllowed = 'move';
   },
 
-  dragEnded(event) {
-    Ember.$(event.target).css('opacity', '1');
+  dragEnded() {
     this.set('currentDragObject', null);
     this.set('currentDragEvent', null);
     this.set('currentDragItem', null);

--- a/tests/integration/components/draggable-object-test.js
+++ b/tests/integration/components/draggable-object-test.js
@@ -122,3 +122,31 @@ test('Draggable Object is only draggable from handle', function(assert) {
   assert.equal($component.attr('draggable'), "false");
 
 });
+
+test('Draggable hooks are overridable', function(assert) {
+  assert.expect(2);
+
+  let event = MockDataTransfer.makeMockEvent();
+
+  this.on('dragStartAction', function(event) {
+    assert.ok(event);
+  });
+
+  this.on('dragEndAction', function(event) {
+    assert.ok(event);
+  });
+
+  this.render(hbs`
+    {{#draggable-object class='draggable-object' dragStartHook=(action 'dragStartAction') dragEndHook=(action 'dragEndAction')}}
+    {{/draggable-object}}
+  `);
+  let $component = this.$('.draggable-object');
+
+  Ember.run(function() {
+    triggerEvent($component, 'dragstart', event);
+  });
+
+  Ember.run(function() {
+    triggerEvent($component, 'dragend', event);
+  });
+});

--- a/tests/unit/components/draggable-object-test.js
+++ b/tests/unit/components/draggable-object-test.js
@@ -74,6 +74,43 @@ test("drop callbacks", function() {
   equal(callbackArgs[0].obj.get('id'),1);
 });
 
+test("dragStartHook", function(assert) {
+  assert.expect(1);
+  var thing = Thing.create({id: 1});
+  var coordinator = Coordinator.create();
+
+  var s = this.subject({coordinator: coordinator});
+  s.set("content",thing);
+
+  s.dragStartHook = function() {
+    assert.ok(true);
+  };
+
+  var event = MockDataTransfer.makeMockEvent();
+  Ember.run(function() {
+    s.dragStart(event);
+  });
+});
+
+test("dragEndHook", function(assert) {
+  assert.expect(1);
+  var thing = Thing.create({id: 1});
+  var coordinator = Coordinator.create();
+
+  var s = this.subject({coordinator: coordinator});
+  s.set("content",thing);
+  s.set("isDraggingObject", true);
+
+  s.dragEndHook = function() {
+    assert.ok(true);
+  };
+
+  var event = MockDataTransfer.makeMockEvent();
+  Ember.run(function() {
+    s.dragEnd(event);
+  });
+});
+
 // test("sim drag", function() {
 //   var thing = Thing.create({id: 1});
 //   var coordinator = Coordinator.create();


### PR DESCRIPTION
This makes the `opacity` inline styling occurring at drag start/end overridable.

Usage example 

```
{{#draggable-object [..] dragStartHook=(action 'dragStartAction')}}
[...]
{{/draggable-object}}
```