### PR TITLE
Adding drag and drop integration test helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,31 @@ The sortingScope is optional and only needed if you have multiple lists on the s
 
 **Note: It's important that you add the isSortable=true to each draggable-object or else that item will be draggable, but will not change the order of any item. Also if you set a custom sortingScope they should be the same for the sortable-object and the draggable-objects it contains.**
 
+## Test Helpers
+
+When writing tests, there is a `drag` helper you can use to help facilitate dragging and dropping. You import it like this:
+
+```javascript
+import { drag } from '../../../helpers/ember-drag-drop';
+```
+
+You can pass the CSS selector for the `draggable-object-target` and pass a `beforeDrop` callback.
+
+An Example:
+
+```javascript
+drag('.draggable-object.drag-handle', {
+  drop: '.draggable-object-target:eq(1)',
+  beforeDrop() {
+    // a chance to inspect state before dropping
+  }
+});
+```
+
+In this example, we're dragging the draggable-object element with CSS selector `.draggable-object.drag-handle` and dropping
+on a draggable-object-target with the CSS selector `draggable-object-target:eq(1)`. Then there's also a chance to
+make assertions in the `beforeDrop` callback.
+
 ### TODO
 
 Theses additions to sort are still incoming:

--- a/test-support/helpers/ember-drag-drop.js
+++ b/test-support/helpers/ember-drag-drop.js
@@ -1,0 +1,51 @@
+import Ember from 'ember';
+import $ from 'jquery';
+import Test from 'ember-test';
+import MockDataTransfer from '../../tests/helpers/data-transfer';
+
+function drop($dragHandle, dropCssPath, dragEvent) {
+  let $dropTarget = $(dropCssPath);
+
+  if (dropTargets.length === 0) {
+    throw(`There are no drop targets by the given selector: '${dropCssPath}'`);
+  }
+
+  Ember.run(() => {
+    triggerEvent($dropTarget, 'dragover', MockDataTransfer.makeMockEvent());
+  });
+
+  Ember.run(() => {
+    triggerEvent($dropTarget, 'drop', MockDataTransfer.makeMockEvent(dragEvent.dataTransfer.get('data.payload')));
+  });
+
+  Ember.run(() => {
+    triggerEvent($module, 'dragend', MockDataTransfer.makeMockEvent());
+  });
+}
+
+export default function() {
+  Test.registerAsyncHelper('drag', function(app, cssPath, options={}) {
+    let dragEvent = MockDataTransfer.makeMockEvent();
+    let $dragHandle = $(cssPath);
+
+    Ember.run(() => {
+      triggerEvent($dragHandle, 'mouseover');
+    });
+
+    Ember.run(() => {
+      triggerEvent($dragHandle, 'dragstart', dragEvent);
+    });
+
+    andThen(function() {
+      if (options.beforeDrop) {
+        options.beforeDrop.call();
+      }
+    });
+
+    andThen(function() {
+      if (options.drop) {
+        drop($dragHandle, options.drop, dragEvent);
+      }
+    });
+  });
+}

--- a/test-support/helpers/ember-drag-drop.js
+++ b/test-support/helpers/ember-drag-drop.js
@@ -6,7 +6,7 @@ import MockDataTransfer from '../../tests/helpers/data-transfer';
 function drop($dragHandle, dropCssPath, dragEvent) {
   let $dropTarget = $(dropCssPath);
 
-  if (dropTargets.length === 0) {
+  if ($dropTarget.length === 0) {
     throw(`There are no drop targets by the given selector: '${dropCssPath}'`);
   }
 
@@ -19,33 +19,31 @@ function drop($dragHandle, dropCssPath, dragEvent) {
   });
 
   Ember.run(() => {
-    triggerEvent($module, 'dragend', MockDataTransfer.makeMockEvent());
+    triggerEvent($dragHandle, 'dragend', MockDataTransfer.makeMockEvent());
   });
 }
 
-export default function() {
-  Test.registerAsyncHelper('drag', function(app, cssPath, options={}) {
-    let dragEvent = MockDataTransfer.makeMockEvent();
-    let $dragHandle = $(cssPath);
+export function drag(cssPath, options={}) {
+  let dragEvent = MockDataTransfer.makeMockEvent();
+  let $dragHandle = $(cssPath);
 
-    Ember.run(() => {
-      triggerEvent($dragHandle, 'mouseover');
-    });
+  Ember.run(() => {
+    triggerEvent($dragHandle, 'mouseover');
+  });
 
-    Ember.run(() => {
-      triggerEvent($dragHandle, 'dragstart', dragEvent);
-    });
+  Ember.run(() => {
+    triggerEvent($dragHandle, 'dragstart', dragEvent);
+  });
 
-    andThen(function() {
-      if (options.beforeDrop) {
-        options.beforeDrop.call();
-      }
-    });
+  andThen(function() {
+    if (options.beforeDrop) {
+      options.beforeDrop.call();
+    }
+  });
 
-    andThen(function() {
-      if (options.drop) {
-        drop($dragHandle, options.drop, dragEvent);
-      }
-    });
+  andThen(function() {
+    if (options.drop) {
+      drop($dragHandle, options.drop, dragEvent);
+    }
   });
 }

--- a/tests/integration/components/helpers-test.js
+++ b/tests/integration/components/helpers-test.js
@@ -1,0 +1,71 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+import startApp from '../../helpers/start-app';
+import Coordinator from '../../../models/coordinator';
+import { drag } from '../../helpers/ember-drag-drop';
+
+let App;
+
+moduleForComponent('ember-drag-drop', 'Integration | Helpers', {
+  integration: true,
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+
+});
+
+const collection = ['hip hop', 'jazz', 'funk'];
+const template = hbs`
+  {{#each collection as |genre index|}}
+    {{#draggable-object coordinator=coordinator content=genre}}
+      <div class="item">{{genre}}</div>
+    {{/draggable-object}}
+
+    {{draggable-object-target class='drop-target' action=dropAction destination=index coordinator=coordinator}}
+  {{/each}}
+`;
+
+test('drag helper drags to a draggable object target and calls the action upon drop', function(assert) {
+  assert.expect(2);
+
+  let coordinator = Coordinator.create();
+
+  coordinator.on('objectMoved', function(ops) {
+    assert.equal(ops.obj, 'hip hop');
+    assert.equal(ops.target.destination, 1);
+  });
+
+  this.set('collection', collection);
+  this.set('coordinator', coordinator);
+  this.render(template);
+
+  drag('.draggable-object:contains("hip hop")', {
+    drop: '.drop-target:eq(1)'
+  });
+});
+
+test('drag helper allows a callback to be called before dropping', function(assert) {
+  assert.expect(3);
+
+  let coordinator = Coordinator.create();
+
+  coordinator.on('objectMoved', function(ops) {
+    assert.equal(ops.obj, 'jazz');
+    assert.equal(ops.target.destination, 2);
+  });
+
+  this.set('collection', collection);
+  this.set('coordinator', coordinator);
+  this.render(template);
+
+  drag('.draggable-object:contains("jazz")', {
+    drop: '.drop-target:eq(2)',
+    beforeDrop: function() {
+      assert.ok($('.is-dragging-object.draggable-object:contains("jazz")'));
+    }
+  });
+});


### PR DESCRIPTION
This PR intended adds a `drag` test helper for integration tests.

For example:

```javascript
drag('.drag-handle-css-selector', {
  beforeDrop: function() {
    // here would be an opportunity to assert things before dropping
  },
  drop: '.drop-target-selector'
});
```