### PR TITLE
Remove log helper.

### DIFF
--- a/app/helpers/log.js
+++ b/app/helpers/log.js
@@ -1,3 +1,0 @@
-export default function() {
-  //console.debug(str);
-};


### PR DESCRIPTION
On Ember 2.10+ overriding a built-in helper triggers an error.

See https://github.com/emberjs/ember.js/issues/14653 for details.

Fixes #77.