### PR TITLE
handle mouseEnter and mouseDown events in DraggableObjectTarget component

### DIFF
--- a/addon/components/draggable-object-target.js
+++ b/addon/components/draggable-object-target.js
@@ -41,6 +41,20 @@ export default Ember.Component.extend(Droppable, {
     }
   },
 
+  mouseDown(e) {
+    let mouseDown = this.get('onMouseDown');
+    if (mouseDown) {
+      mouseDown(e.originalEvent);
+    }
+  },
+
+  mouseEnter(e) {
+    let mouseEnter = this.get('onMouseEnter');
+    if (mouseEnter) {
+      mouseEnter(e.originalEvent);
+    }
+  },
+
   actions: {
     acceptForDrop: function() {
       var hashId = this.get('coordinator.clickedId');


### PR DESCRIPTION
Hey, thanks for this awesome addon.

I happened to need to support mouseDown and mouseEnter events in one of the apps, I thought it would be nice to have a support for those in the addon itself without the need to extend it if someone else needs to handle them. I went with the same approach as here: https://github.com/mharris717/ember-drag-drop/pull/30, so the API for that looks like this:

``` hbs
{{#draggable-object-target onMouseEnter=(action "myAwesomeAction") onMouseDown=(action "doSomethigOnMouseDown")}}
{{/draggable-object-target}}
```