### PR TITLE
Ignore drops of objects not managed by the dragCoordinator

### DIFF
--- a/addon/components/draggable-object-target.js
+++ b/addon/components/draggable-object-target.js
@@ -14,6 +14,7 @@ export default Ember.Component.extend(Droppable, {
   handleDrop: function(event) {
     var dataTransfer = event.dataTransfer;
     var payload = dataTransfer.getData("Text");
+    if (payload === "") { return; }
     this.handlePayload(payload, event);
   },
 


### PR DESCRIPTION
### Problem
We've run into problems when users drag objects, such as files, into drop targets that are not managed by ember-drag-drop. This results in a hard-to-debug `no obj for key` error. 

### Solution
This PR adds an empty-check on the handleDrop that prevents it from trying to lookup non-existent keys on the dragCoordinator. 

Perhaps you have some fixes in the works for this but this gets us past the problem in the meantime. 