### PR TITLE
Don't need to copy all elements over before setting object list

### DIFF
--- a/addon/services/drag-coordinator.js
+++ b/addon/services/drag-coordinator.js
@@ -95,33 +95,24 @@ export default Ember.Service.extend({
         //use swap algorithm
         // Swap if items are in the same sortable-objects component
         const newList = aSortable.get('sortableObjectList').toArray();
-        const newArray = Ember.A();
         const aPos = newList.indexOf(a);
         const bPos = newList.indexOf(b);
 
         newList[aPos] = b;
         newList[bPos] = a;
 
-        newList.forEach(function(item) {
-          newArray.push(item);
-        });
-        aSortable.set('sortableObjectList', newArray);
+        aSortable.set('sortableObjectList', newList);
 
       } else {
         //use shift algorithm
         const newList = aSortable.get('sortableObjectList').toArray();
-        var newArray = Ember.A();
         var aPos = newList.indexOf(a);
         var bPos = newList.indexOf(b);
 
         newList.splice(aPos, 1);
         newList.splice(bPos, 0, a);
 
-        newList.forEach(function(item){
-          newArray.push(item);
-        });
-
-        aSortable.set('sortableObjectList', newArray);
+        aSortable.set('sortableObjectList', newList);
       }
 
 


### PR DESCRIPTION
Been trying to iron out a performance issue I'm having that appears to originate in this method--possibly due to the sortable object list being an ember-data object's (large) `hasMany` relationship.

To be clear, this doesn't solve my problem, it just looked like a remnant from refactoring, so I figured why not.

Thanks for the work, and I will update #68 if I make more headway on my perf issue.