### PR TITLE
Add option to sort in-place

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ This only applies if you use the sort capabilities, regular dragging is not vers
 An Example:
 
 ```handlebars
-{{#sortable-objects sortableObjectList=sortableObjectList sortEndAction='sortEndAction' enableSort=true useSwap=true sortingScope="sortingGroup"}}
+{{#sortable-objects sortableObjectList=sortableObjectList sortEndAction='sortEndAction' enableSort=true useSwap=true inPlace=false sortingScope="sortingGroup"}}
   {{#each sortableObjectList as |item|}}
     {{#draggable-object content=item isSortable=true sortingScope="sortingGroup"}}
       {{item.name}}
@@ -194,9 +194,11 @@ An Example:
 
 On drop of an item in the list, the sortableObjectList is re-ordered and the sortEndAction is fired unless the optional parameter 'enableSort' is false. You can check out an example of this is action [here](http://mharris717.github.io/ember-drag-drop/)
 
-useSwap defaults to true and is optional. If you set it to false, then the sort algorithm will cascade the swap of items, pushing the values down the list. [See Demo](http://mharris717.github.io/ember-drag-drop/horizontal)
+`useSwap` defaults to true and is optional. If you set it to false, then the sort algorithm will cascade the swap of items, pushing the values down the list. [See Demo](http://mharris717.github.io/ember-drag-drop/horizontal)
 
-The sortingScope is optional and only needed if you have multiple lists on the screen that you want to share dragging between. [See Demo](http://mharris717.github.io/ember-drag-drop/multiple)
+`inPlace` defaults to false and is optional. If you set it to true, then the original list will be mutated instead of making a copy.
+
+`sortingScope` is optional and only needed if you have multiple lists on the screen that you want to share dragging between. [See Demo](http://mharris717.github.io/ember-drag-drop/multiple)
 
 **Note: It's important that you add the isSortable=true to each draggable-object or else that item will be draggable, but will not change the order of any item. Also if you set a custom sortingScope they should be the same for the sortable-object and the draggable-objects it contains.**
 

--- a/addon/components/sortable-objects.js
+++ b/addon/components/sortable-objects.js
@@ -7,6 +7,7 @@ export default Ember.Component.extend( {
   classNameBindings: ['overrideClass'],
   enableSort: true,
   useSwap: true,
+  inPlace: false,
   sortingScope: 'drag-objects',
   sortableObjectList: Ember.A(),
 

--- a/addon/services/drag-coordinator.js
+++ b/addon/services/drag-coordinator.js
@@ -1,5 +1,21 @@
 import Ember from 'ember';
 
+function swapInPlace(items, a, b) {
+  const aPos = items.indexOf(a);
+  const bPos = items.indexOf(b);
+
+  items.replace(aPos, 1, [ b ]);
+  items.replace(bPos, 1, [ a ]);
+}
+
+function shiftInPlace(items, a, b) {
+  const aPos = items.indexOf(a);
+  const bPos = items.indexOf(b);
+
+  items.removeAt(aPos);
+  items.insertAt(bPos, a);
+}
+
 export default Ember.Service.extend({
   sortComponentController: null,
   currentDragObject: null,
@@ -13,6 +29,8 @@ export default Ember.Service.extend({
   arrayList: Ember.computed.alias('sortComponentController.sortableObjectList'),
   enableSort: Ember.computed.alias('sortComponentController.enableSort'),
   useSwap: Ember.computed.alias('sortComponentController.useSwap'),
+  inPlace: Ember.computed.alias('sortComponentController.inPlace'),
+
   pushSortComponent(component) {
     const sortingScope = component.get('sortingScope');
     if (!this.get('sortComponents')[sortingScope]) {
@@ -91,30 +109,20 @@ export default Ember.Service.extend({
 
     if (swap) {
 
-      if (this.get('useSwap')) {
-        //use swap algorithm
-        // Swap if items are in the same sortable-objects component
-        const newList = aSortable.get('sortableObjectList').toArray();
-        const aPos = newList.indexOf(a);
-        const bPos = newList.indexOf(b);
-
-        newList[aPos] = b;
-        newList[bPos] = a;
-
-        aSortable.set('sortableObjectList', newList);
-
-      } else {
-        //use shift algorithm
-        const newList = aSortable.get('sortableObjectList').toArray();
-        var aPos = newList.indexOf(a);
-        var bPos = newList.indexOf(b);
-
-        newList.splice(aPos, 1);
-        newList.splice(bPos, 0, a);
-
-        aSortable.set('sortableObjectList', newList);
+      let list = aSortable.get('sortableObjectList');
+      if (!this.get('inPlace')) {
+        list = list.toArray();
       }
 
+      if (this.get('useSwap')) {
+        swapInPlace(list, a, b);
+      } else {
+        shiftInPlace(list, a, b);
+      }
+
+      if (!this.get('inPlace')) {
+        aSortable.set('sortableObjectList', list);
+      }
 
     } else {
       // Move if items are in different sortable-objects component

--- a/tests/integration/components/sortable-objects-test.js
+++ b/tests/integration/components/sortable-objects-test.js
@@ -196,4 +196,37 @@ test('sorting does not happen if off', async function(assert) {
 
   assert.equal(sortEndActionCalled, false);
 });
+
+test('sort in place', async function(assert) {
+  const mutableData = Ember.A(pojoData.slice());
+  this.set('pojoData', mutableData);
+
+  this.render(hbs`
+    {{#sortable-objects sortableObjectList=pojoData class='sortContainer' useSwap=false inPlace=true}}
+      {{#each pojoData as |item|}}
+        {{#draggable-object content=item overrideClass='sortObject' isSortable=true}}
+          {{item.title}}
+        {{/draggable-object}}
+      {{/each}}
+    {{/sortable-objects}}
+  `);
+
+  assert.equal(this.$('.sortObject').length, 4);
+
+  let startDragSelector = '.sortObject:nth-child(1)',
+    dragOver2Selector = '.sortObject:nth-child(2)',
+    dragOver3Selector = '.sortObject:nth-child(3)';
+
+  await drag(startDragSelector, {
+    drop: dragOver3Selector,
+    dragOverMoves: [
+      [{ clientX: 1, clientY: 500 }, dragOver2Selector],
+      [{ clientX: 1, clientY: 750 }, dragOver3Selector]
+    ]
+  });
+
+  assert.equal(mutableData, this.get('pojoData'), 'array reference should not change');
+  assert.deepEqual(mutableData.mapBy('id'), [2, 3, 1, 4], 'original array should be mutated');
+});
+
 //need to test ember data objects


### PR DESCRIPTION
This is useful when dealing with ember-data: usually you have a special ArrayProxy with other properties/methods on it. As soon as you sort, your ArrayProxy gets replaced with a plain array. An `inPlace` option prevents that.