### PR TITLE
Support Node.js 4.x LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,6 @@
     "type": "git",
     "url": "https://github.com/mharris717/ember-drag-drop"
   },
-  "engines": {
-    "node": ">= 6"
-  },
   "author": "",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Node 4 is still in LTS until April next year and the only thing I can see that's preventing this package supporting node 4 is the `engines` declaration in `package.json` which stops `yarn install` (and maybe `npm install` - I haven't tested that) from running on 4.x when this package is included in a consuming application.

This PR removes the `engines` declaration to match [Ember's own package.json](https://github.com/emberjs/ember.js/blob/master/package.json) and become node version agnostic.