### PR TITLE
Move content cache to instance to prevent state leak

### DIFF
--- a/app/models/obj-hash.js
+++ b/app/models/obj-hash.js
@@ -1,9 +1,13 @@
 import Ember from 'ember';
 
 export default Ember.Object.extend({
-  content: {},
   contentLength: 0,
   length: Ember.computed.alias('contentLength'),
+
+  init: function() {
+    this._super();
+    this.content = {};
+  },
 
   add: function(obj) {
     var id = this.generateId();


### PR DESCRIPTION
I am currently working on cleaning up some memory leaks across test runs in a very large application. I have noticed that the content property in obj-hash.js is causing an application container instance to persist across test runs when it should be completely destroy and garbage collected. This change shouldn't affect any logic - just moving the content property from the prototype to the instance. I confirmed by taking a heap snapshot after test runs in my application that this change allows the application container to get properly garbage collected. I also ran the tests for this addon locally and everything still looks good. Thanks!