### PR TITLE
Fix inconsistency when component is removed on drop

### DIFF
--- a/addon/components/draggable-object.js
+++ b/addon/components/draggable-object.js
@@ -47,6 +47,9 @@ export default Ember.Component.extend({
     if (this.$(dragHandle)) {
       this.$(dragHandle).off();
     }
+    if (this.get('isDraggingObject')) {
+      this.get('dragCoordinator').dragEnded();
+    }
   },
 
   dragStart(event) {


### PR DESCRIPTION
If a drop action causes the draggable component instance to be
destroyed, the dragEnd event isn't fired, resulting in the
dragCoordinator being left in an inconsistent state (it thinks the
object is still being dragged). This change ensures the dragCoordinator
state gets cleaned up before the draggable-object is destroyed.

Note that this fix still won't result in the dragEndHook or dragEndAction
being fired: both of them are still only triggered if a browser dragEnd
event fires. It's not clear if they can be caused to fire in this
case without breaking the API, since both take the dragEnd event
as a parameter, which doesn't exist in this case.

This seems fine for dragEndHook, since it appears to mostly be used for DOM
changes/cleanup and this section of the DOM is going away, but it feels a
bit strange that dragEndAction wouldn't be fired.

Two possible options:
- send dragEndAction without an event
- add a new "dragFinally" action that gets called in both cases

Related to #118