### PR TITLE
Improve the handling of coordinates when sorting horizontally

### DIFF
--- a/addon/services/drag-coordinator.js
+++ b/addon/services/drag-coordinator.js
@@ -62,18 +62,26 @@ export default Ember.Service.extend({
     const currentOffsetItem = this.get('currentOffsetItem');
     const pos = this.relativeClientPosition(emberObject.$()[0], event);
     const hasSameSortingScope = this.get('currentDragItem.sortingScope') === emberObject.get('sortingScope');
-    let moveDirection = false;
+    let moveDirections = [];
 
     if (!this.get('lastEvent')) {
       this.set('lastEvent', event);
     }
 
     if (event.originalEvent.clientY < this.get('lastEvent').originalEvent.clientY) {
-      moveDirection = 'up';
+      moveDirections.push('up');
     }
 
     if (event.originalEvent.clientY > this.get('lastEvent').originalEvent.clientY) {
-      moveDirection = 'down';
+      moveDirections.push('down');
+    }
+
+    if (event.originalEvent.clientX < this.get('lastEvent').originalEvent.clientX) {
+      moveDirections.push('left');
+    }
+
+    if (event.originalEvent.clientX > this.get('lastEvent').originalEvent.clientX) {
+      moveDirections.push('right');
     }
 
     this.set('lastEvent', event);
@@ -81,7 +89,10 @@ export default Ember.Service.extend({
     if (!this.get('isMoving')) {
       if (event.target !== this.get('currentDragEvent').target && hasSameSortingScope) { //if not dragging over self
         if (currentOffsetItem !== emberObject) {
-          if (pos.py > 0.33 && moveDirection === 'up' || pos.py > 0.33 && moveDirection === 'down') {
+          if (pos.py < 0.67 && moveDirections.indexOf('up') >= 0 ||
+              pos.py > 0.33 && moveDirections.indexOf('down') >= 0 ||
+              pos.px < 0.67 && moveDirections.indexOf('left') >= 0 ||
+              pos.px > 0.33 && moveDirections.indexOf('right') >= 0) {
 
             this.moveElements(emberObject);
             this.set('currentOffsetItem', emberObject);


### PR DESCRIPTION
Horizontal sorting currently does not swap elements properly if the `x` coordinate stays the same. Basically your cursor needs to move slightly up/down (in addition to the left/right movement) for horizontal scrolling to work.

This is usually not a problem, since people are not that precise. However I am writing some browser integration tests and it's always the middle of buttons that are clicked/dragged/dropped. That helped me notice the problem.

This, however, changes the area you need to drag over to trigger reordering of the sortable items. It used to be a horizontal strip that was checked for vertical movement. Now it's more like a cross and each coordinate is checked.