### PR TITLE
Bump ember-cli-babel to quiet deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli-github-pages": "0.1.2",
     "ember-cli-eslint": "^3.1.0",
     "ember-cli-htmlbars": "^1.1.1",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-htmlbars-inline-precompile": "^0.4.0",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^3.1.0",
     "ember-cli-shims": "^1.0.2",
@@ -39,14 +39,13 @@
     "ember-native-dom-helpers": "^0.4.1",
     "ember-resolver": "^2.0.3",
     "ember-source": "~2.12.0",
-    "ember-welcome-page": "^2.0.2",
     "loader.js": "^4.2.3"
   },
   "keywords": [
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.2.4"
+    "ember-cli-babel": "^6.6.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/testem.js
+++ b/testem.js
@@ -12,10 +12,15 @@ module.exports = {
     "Chrome"
   ],
   'browser_args': {
-    'Chrome': [
-      '--disable-gpu',
-      '--headless',
-      '--remote-debugging-port=9222'
-    ]
+    'Chrome': {
+      mode: 'ci',
+      args: [
+        '--disable-gpu',
+        '--headless',
+        '--remote-debugging-port=9222',
+        // --no-sandbox is needed when running Chrome inside a container
+        process.env.TRAVIS ? '--no-sandbox' : null
+      ].filter(Boolean)
+    }
   }
 };


### PR DESCRIPTION
Cleans up this warning when this addon is used, fixes #121 

`DEPRECATION: ember-cli-babel 5.x has been deprecated. Please upgrade to at least ember-cli-babel 6.6`

Also removed `ember-welcome-page` since it's not needed.

EDIT: fixed travis testem config so build passes

@mharris717 @sbatson5 @dgavey