### PR TITLE
Fix using Ember.Array methods on a native array

### DIFF
--- a/addon/services/drag-coordinator.js
+++ b/addon/services/drag-coordinator.js
@@ -111,7 +111,7 @@ export default Ember.Service.extend({
 
       let list = aSortable.get('sortableObjectList');
       if (!this.get('inPlace')) {
-        list = list.toArray();
+        list = Ember.A(list.toArray());
       }
 
       if (this.get('useSwap')) {


### PR DESCRIPTION
Ember.Array#toArray returns a native array so we should wrap it again.

This broke in Ember 3.3.