### PR TITLE
deprecate jquery-event for Ember 3.3

### DIFF
--- a/addon/components/draggable-object-target.js
+++ b/addon/components/draggable-object-target.js
@@ -44,21 +44,21 @@ export default Component.extend(Droppable, {
   click(e) {
     let onClick = this.get('onClick');
     if (onClick) {
-      onClick(e.originalEvent);
+      onClick(e);
     }
   },
 
   mouseDown(e) {
     let mouseDown = this.get('onMouseDown');
     if (mouseDown) {
-      mouseDown(e.originalEvent);
+      mouseDown(e);
     }
   },
 
   mouseEnter(e) {
     let mouseEnter = this.get('onMouseEnter');
     if (mouseEnter) {
-      mouseEnter(e.originalEvent);
+      mouseEnter(e);
     }
   },
 

--- a/addon/services/drag-coordinator.js
+++ b/addon/services/drag-coordinator.js
@@ -75,11 +75,11 @@ export default Service.extend({
       this.set('lastEvent', event);
     }
 
-    if (event.originalEvent.clientY < this.get('lastEvent').originalEvent.clientY) {
+    if (event.clientY < this.get('lastEvent').clientY) {
       moveDirection = 'up';
     }
 
-    if (event.originalEvent.clientY > this.get('lastEvent').originalEvent.clientY) {
+    if (event.clientY > this.get('lastEvent').clientY) {
       moveDirection = 'down';
     }
 
@@ -160,8 +160,8 @@ export default Service.extend({
 
   relativeClientPosition(el, event) {
     const rect = el.getBoundingClientRect();
-    const x = event.originalEvent.clientX - rect.left;
-    const y = event.originalEvent.clientY - rect.top;
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
 
     return {
       x: x,

--- a/test-support/helpers/data-transfer.js
+++ b/test-support/helpers/data-transfer.js
@@ -14,11 +14,10 @@ c.reopenClass({
   makeMockEvent: function(payload) {
     var transfer = this.create({payload: payload});
     var res = {dataTransfer: transfer};
-    res.originalEvent = res;
-    res.originalEvent.preventDefault = function() {
+    res.preventDefault = function() {
       console.log('prevent default');
     };
-    res.originalEvent.stopPropagation = function() {
+    res.stopPropagation = function() {
       console.log('stop propagation');
     };
     return res;

--- a/test-support/helpers/mock-event.js
+++ b/test-support/helpers/mock-event.js
@@ -20,7 +20,6 @@ export default class MockEvent {
   constructor(options = {}) {
     this.dataTransfer = new DataTransfer();
     this.dataTransfer.setData('Text', options.dataTransferData);
-    this.originalEvent = this;
     this.setProperties(options)
   }
 


### PR DESCRIPTION
The use of `event.originalEvent` is throwing hundreds of console warnings in my Ember 3.5 app. This PR aims to replace jquery-event with Ember's own event:
https://deprecations-app-prod.herokuapp.com/deprecations/v3.x/#toc_jquery-event