### PR TITLE
Guard against missing currentDragEvent

### DIFF
--- a/addon/services/drag-coordinator.js
+++ b/addon/services/drag-coordinator.js
@@ -85,7 +85,7 @@ export default Service.extend({
 
     this.set('lastEvent', event);
 
-    if (!this.get('isMoving')) {
+    if (!this.get('isMoving') && this.get('currentDragEvent')) {
       if (event.target !== this.get('currentDragEvent').target && hasSameSortingScope) { //if not dragging over self
         if (currentOffsetItem !== emberObject) {
           if (pos.py > 0.33 && moveDirection === 'up' || pos.py > 0.33 && moveDirection === 'down') {


### PR DESCRIPTION
I know this isn't really a "solution" -- just a quick hack -- but it prevents https://github.com/mharris717/ember-drag-drop/issues/146