### PR TITLE
Use normalizeEvent so that addon works if app uses jQuery

### DIFF
--- a/addon/components/draggable-object-target.js
+++ b/addon/components/draggable-object-target.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import Droppable from 'ember-drag-drop/mixins/droppable';
+import { normalizeEvent } from 'ember-jquery-legacy';
 
 export default Component.extend(Droppable, {
   classNameBindings: ['overrideClass'],
@@ -44,21 +45,21 @@ export default Component.extend(Droppable, {
   click(e) {
     let onClick = this.get('onClick');
     if (onClick) {
-      onClick(e);
+      onClick(normalizeEvent(e));
     }
   },
 
   mouseDown(e) {
     let mouseDown = this.get('onMouseDown');
     if (mouseDown) {
-      mouseDown(e);
+      mouseDown(normalizeEvent(e));
     }
   },
 
   mouseEnter(e) {
     let mouseEnter = this.get('onMouseEnter');
     if (mouseEnter) {
-      mouseEnter(e);
+      mouseEnter(normalizeEvent(e));
     }
   },
 

--- a/addon/services/drag-coordinator.js
+++ b/addon/services/drag-coordinator.js
@@ -1,6 +1,7 @@
 import Service from '@ember/service';
 import { alias } from '@ember/object/computed';
 import { A } from '@ember/array';
+import { normalizeEvent } from 'ember-jquery-legacy';
 
 function swapInPlace(items, a, b) {
   const aPos = items.indexOf(a);
@@ -66,27 +67,28 @@ export default Service.extend({
   },
 
   draggingOver(event, emberObject) {
+    const normalizedEvent = normalizeEvent(event);
     const currentOffsetItem = this.get('currentOffsetItem');
-    const pos = this.relativeClientPosition(emberObject.element, event);
+    const pos = this.relativeClientPosition(emberObject.element, normalizedEvent);
     const hasSameSortingScope = this.get('currentDragItem.sortingScope') === emberObject.get('sortingScope');
     let moveDirection = false;
 
     if (!this.get('lastEvent')) {
-      this.set('lastEvent', event);
+      this.set('lastEvent', normalizedEvent);
     }
 
-    if (event.clientY < this.get('lastEvent').clientY) {
+    if (normalizedEvent.clientY < this.get('lastEvent').clientY) {
       moveDirection = 'up';
     }
 
-    if (event.clientY > this.get('lastEvent').clientY) {
+    if (normalizedEvent.clientY > this.get('lastEvent').clientY) {
       moveDirection = 'down';
     }
 
-    this.set('lastEvent', event);
+    this.set('lastEvent', normalizedEvent);
 
     if (!this.get('isMoving')) {
-      if (event.target !== this.get('currentDragEvent').target && hasSameSortingScope) { //if not dragging over self
+      if (normalizedEvent.target !== this.get('currentDragEvent').target && hasSameSortingScope) { //if not dragging over self
         if (currentOffsetItem !== emberObject) {
           if (pos.py > 0.33 && moveDirection === 'up' || pos.py > 0.33 && moveDirection === 'down') {
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "ember-cli": "~3.3.0",
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",
+    "ember-cli-github-pages": "0.2.0",
     "ember-cli-htmlbars": "^2.0.1",
     "ember-cli-htmlbars-inline-precompile": "^1.0.0",
     "ember-cli-inject-live-reload": "^1.4.1",
@@ -24,7 +25,6 @@
     "ember-data": "^3.0.2",
     "ember-disable-prototype-extensions": "^1.1.2",
     "ember-export-application-global": "^2.0.0",
-    "ember-cli-github-pages": "0.2.0",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-native-dom-helpers": "^0.4.1",
@@ -51,7 +51,8 @@
     "test": "tests"
   },
   "dependencies": {
-    "ember-cli-babel": "^6.6.0"
+    "ember-cli-babel": "^6.6.0",
+    "ember-jquery-legacy": "^1.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",


### PR DESCRIPTION
After #141, this addon no longer works for apps that use jQuery. Sorry to `@` you @dgavey, but this is a show stopper 😫

Several event properties used by this addon are not available when the consuming app uses jQuery, so this PR uses `normalizeEvent` so that it works no matter what.

More info on events and supporting jQuery and non-Jquery apps [here](https://github.com/emberjs/rfcs/blob/master/text/0294-optional-jquery.md#introducing-ember-jquery-legacy-and-deprecating-jqueryevent-usage)