### PR TITLE
Use preventDefault when dropping

### DIFF
--- a/addon/components/sortable-objects.js
+++ b/addon/components/sortable-objects.js
@@ -47,6 +47,7 @@ export default Component.extend( {
 
   drop(event) {
     event.stopPropagation();
+    event.preventDefault();
     this.set('dragCoordinator.sortComponentController', undefined);
     if (this.get('enableSort') && this.get('sortEndAction')) {
       this.get('sortEndAction')(event);


### PR DESCRIPTION
Without this Firefox sometimes follows a link to a random numeric place.

This appears to be a recurrence of #10. It can be seen on the dummy app most repeatably by 
1) navigating to the Simple Sorting with Ember Data example
2) Click and drag from the text of the third item
3) Drop it so the text you're dragging falls in the space between the first and second item.

Adding a `preventDefault` call to the event solves this issue and prevents firefox from attempting to open a random URL like `http://702700786646/`. I don't think it's possible to add tests to this.