### PR TITLE
Use Ember's util/isEqual in sortable components

### DIFF
--- a/addon/services/drag-coordinator.js
+++ b/addon/services/drag-coordinator.js
@@ -1,19 +1,26 @@
 import Service from '@ember/service';
 import { alias } from '@ember/object/computed';
 import { A } from '@ember/array';
+import { isEqual } from '@ember/utils';
 import { normalizeEvent } from 'ember-jquery-legacy';
 
+function indexOf(items, a) {
+  return items.findIndex(function (element) {
+    return isEqual(element, a);
+  });
+}
+
 function swapInPlace(items, a, b) {
-  const aPos = items.indexOf(a);
-  const bPos = items.indexOf(b);
+  const aPos = indexOf(items, a);
+  const bPos = indexOf(items, b);
 
   items.replace(aPos, 1, [ b ]);
   items.replace(bPos, 1, [ a ]);
 }
 
 function shiftInPlace(items, a, b) {
-  const aPos = items.indexOf(a);
-  const bPos = items.indexOf(b);
+  const aPos = indexOf(items, a);
+  const bPos = indexOf(items, b);
 
   items.removeAt(aPos);
   items.insertAt(bPos, a);
@@ -106,12 +113,12 @@ export default Service.extend({
   moveObjectPositions(a, b, sortComponents) {
     const aSortable = sortComponents.find((component) => {
       return component.get('sortableObjectList').find((sortable) => {
-        return sortable === a;
+        return isEqual(sortable, a);
       });
     });
     const bSortable = sortComponents.find((component) => {
       return component.get('sortableObjectList').find((sortable) => {
-        return sortable === b;
+        return isEqual(sortable, b);
       });
     });
     const swap = aSortable === bSortable;
@@ -140,7 +147,7 @@ export default Service.extend({
 
       // Remove from aList and insert into bList
       aList.removeObject(a);
-      bList.insertAt(bList.indexOf(b), a);
+      bList.insertAt(indexOf(bList, b), a);
     }
   },
 


### PR DESCRIPTION
It is currently hard to use certain implementations of array proxies with the `sortable-objects` component.

By using Ember's [isEqual](https://api.emberjs.com/ember/release/functions/@ember%2Futils/isEqual) it is delegated to the users of the library to determine if items in lists are equal. If the users choose no to implement `isEqual`, the bahaviour will be the same as the current one - comparison with `===`.