### PR TITLE
Ember mouseEnter deprecation

### DIFF
--- a/addon/components/draggable-object-target.js
+++ b/addon/components/draggable-object-target.js
@@ -55,11 +55,21 @@ export default Component.extend(Droppable, {
     }
   },
 
-  mouseEnter(e) {
+  handleMouseEnter(e) {
     let mouseEnter = this.get('onMouseEnter');
     if (mouseEnter) {
       mouseEnter(e);
     }
+  },
+
+  didInsertElement() {
+      this._super(...arguments);
+      this.element.addEventListener('mouseenter', this.handleMouseEnter);
+  },
+
+  willDestroyElement() {
+      this._super(...arguments);
+      this.element.removeEventListener('mouseenter', this.handleMouseEnter);
   },
 
   actions: {


### PR DESCRIPTION
https://deprecations.emberjs.com/v3.x/#toc_component-mouseenter-leave-move