### PR TITLE
Throw Errors, not strings

### DIFF
--- a/addon/components/object-bin.js
+++ b/addon/components/object-bin.js
@@ -7,7 +7,7 @@ function removeOne(arr,obj) {
   var l2 = arr.get('length');
 
   if (l-1 !== l2) {
-    throw "bad length " + l + " " + l2;
+    throw new Error("bad length " + l + " " + l2);
   }
 }
 

--- a/app/models/obj-hash.js
+++ b/app/models/obj-hash.js
@@ -21,7 +21,7 @@ export default EmberObject.extend({
   getObj: function(key) {
     var res = this.get('content')[key];
     if (!res) {
-      throw "no obj for key "+key;
+      throw new Error("no obj for key "+key);
     }
     return res;
   },

--- a/test-support/helpers/drag-drop.js
+++ b/test-support/helpers/drag-drop.js
@@ -17,7 +17,7 @@ async function drop(dragSelector, dragEvent, options) {
 
   let dropElement = await find(dropSelector);
   if (!dropElement) {
-    throw(`There are no drop targets by the given selector: '${dropSelector}'`);
+    throw new Error(`There are no drop targets by the given selector: '${dropSelector}'`);
   }
 
   await dragOver(dropSelector, dragOverMoves);

--- a/test-support/helpers/ember-drag-drop.js
+++ b/test-support/helpers/ember-drag-drop.js
@@ -6,7 +6,7 @@ function drop($dragHandle, dropCssPath, dragEvent) {
   let dropTarget = document.querySelector(dropCssPath);
 
   if (dropTarget.length === 0) {
-    throw(`There are no drop targets by the given selector: '${dropCssPath}'`);
+    throw new Error(`There are no drop targets by the given selector: '${dropCssPath}'`);
   }
 
   run(() => {


### PR DESCRIPTION
so Bugsnag and the like can get a stacktrace, and not complain about it being a string.
This has been a problem for me when users have been dragging unexpected things onto a dropzone, giving me "no object for key" errors coming up in the Bugsnag online service without a stacktrace to help figure out where it was coming from.

I'm only a part-time javascript hack so could be wrong about this fixing my problem, but stackoverflow chatter seems to support the notion.

https://stackoverflow.com/questions/11502052/throwing-strings-instead-of-errors https://stackoverflow.com/questions/9156176/what-is-the-difference-between-throw-new-error-and-throw-someobject
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error

I've `yarn run ember try:each` on node v10.22.0 and it passes.