### PR TITLE
Don't sendAction if isDestroyed or isDestroying

### DIFF
--- a/app/models/coordinator.js
+++ b/app/models/coordinator.js
@@ -13,11 +13,11 @@ export default EmberObject.extend(Evented, {
     ops = ops || {};
     var payload = this.get('objectMap').getObj(id);
 
-    if (payload.ops.source) {
+    if (payload.ops.source && !payload.ops.source.isDestroying && !payload.ops.source.isDestroyed) {
       payload.ops.source.sendAction('action',payload.obj);
     }
 
-    if (payload.ops.target) {
+    if (payload.ops.target && !payload.ops.target.isDestroying && !payload.ops.target.isDestroyed) {
       payload.ops.target.sendAction('action',payload.obj);
     }
 


### PR DESCRIPTION
There may be circumstances where a drag source or drag target are destroyed mid-drag. Such a situation is common in the app that I work on. 

In this situation, the coordinator's getObject method will throw an unhandled error when attempting to call sendAction on the destroyed object. This updates the coordinator's getObject method to guard against calling sendAction on a source/target that isDestroying or isDestroyed.