### PR TITLE
Remove an implicit injection

### DIFF
--- a/addon/components/draggable-object-target.js
+++ b/addon/components/draggable-object-target.js
@@ -1,3 +1,4 @@
+import { getOwner } from '@ember/application';
 import Component from '@ember/component';
 import Droppable from 'ember-drag-drop/mixins/droppable';
 
@@ -5,6 +6,18 @@ export default Component.extend(Droppable, {
   classNameBindings: ['overrideClass'],
   overrideClass: 'draggable-object-target',
   isOver: false,
+
+  // idea taken from https://github.com/emberjs/rfcs/blob/master/text/0680-implicit-injection-deprecation.md#stage-1
+  get coordinator() {
+    if (this._coordinator === undefined) {
+      this._coordinator = getOwner(this).lookup('drag:coordinator');
+    }
+
+    return this._coordinator;
+  },
+  set coordinator(value) {
+    this._coordinator = value;
+  },
 
   handlePayload(payload, event) {
     let obj = this.get('coordinator').getObject(payload,{target: this});

--- a/addon/components/draggable-object.js
+++ b/addon/components/draggable-object.js
@@ -1,3 +1,4 @@
+import { getOwner } from '@ember/application';
 import Component from '@ember/component';
 import { inject as service} from '@ember/service';
 import { alias } from '@ember/object/computed';
@@ -16,6 +17,18 @@ export default Component.extend({
   isSortable: false,
   sortingScope: 'drag-objects',
   title: alias('content.title'),
+
+  // idea taken from https://github.com/emberjs/rfcs/blob/master/text/0680-implicit-injection-deprecation.md#stage-1
+  get coordinator() {
+    if (this._coordinator === undefined) {
+      this._coordinator = getOwner(this).lookup('drag:coordinator');
+    }
+
+    return this._coordinator;
+  },
+  set coordinator(value) {
+    this._coordinator = value;
+  },
 
   draggable: computed('isDraggable', function() {
     let isDraggable = this.get('isDraggable');

--- a/app/initializers/coordinator-setup.js
+++ b/app/initializers/coordinator-setup.js
@@ -6,6 +6,5 @@ export default {
   initialize: function() {
     let app = arguments[1] || arguments[0];
     app.register("drag:coordinator",Coordinator);
-    app.inject("component","coordinator","drag:coordinator");
   }
 };


### PR DESCRIPTION
Because that's deprecated in Ember 3.26

cc @dgavey