### PR TITLE
Adding `types` properties into mocked DataTransfer

### DIFF
--- a/addon-test-support/helpers/mock-event.js
+++ b/addon-test-support/helpers/mock-event.js
@@ -1,26 +1,32 @@
 class DataTransfer {
   constructor() {
     this.data = {};
+    this.types = [];
   }
 
   setData(type, value) {
+    const _type = type === 'Text' ? 'text/plain' : type;
+
+    if (!this.types.includes(_type)) {
+      this.types.push(_type);
+    }
+
     this.data[type] = value;
     return this;
   }
 
-  getData(type = "Text") {
+  getData(type = 'Text') {
     return this.data[type];
   }
 
-  setDragImage() {
-  }
+  setDragImage() {}
 }
 
 export default class MockEvent {
   constructor(options = {}) {
     this.dataTransfer = new DataTransfer();
     this.dataTransfer.setData('Text', options.dataTransferData);
-    this.setProperties(options)
+    this.setProperties(options);
   }
 
   useDataTransferData(otherEvent) {
@@ -35,15 +41,13 @@ export default class MockEvent {
     return this;
   }
 
-  preventDefault() {
-  }
+  preventDefault() {}
 
-  stopPropagation() {
-  }
+  stopPropagation() {}
 }
 
 export function createDomEvent(type) {
-  let event = document.createEvent("CustomEvent");
+  let event = document.createEvent('CustomEvent');
   event.initCustomEvent(type, true, true, null);
   event.dataTransfer = new DataTransfer();
   return event;


### PR DESCRIPTION
Hey there!

We've been using this addon quite intensively lately, thanks for the hard work!
In order to be able to check the validity of the drag event, we ended up doing this:

```
import DraggableObjectTarget from 'ember-drag-drop/components/draggable-object-target';

export default class CustomDraggableObjectTarget extends DraggableObjectTarget {
  validateDragEvent(event) {
    return event.dataTransfer.types.length === 1 && event.dataTransfer.types.includes('text/plain');
  }
}
```

But the problem introduced is that we can no longer use the `drag` test-helper.
This PR aims at adding a `types` property in the mocked DataTransfer :)

Let me know if you see anything I may rework!

Thanks!