### PR TITLE
Remove object-bin export

### DIFF
--- a/app/components/object-bin.js
+++ b/app/components/object-bin.js
@@ -1,3 +1,0 @@
-import ObjectBin from 'ember-drag-drop/components/object-bin';
-
-export default ObjectBin;


### PR DESCRIPTION
This component was removed in #184, but the app export left behind which
embroider hates. Removed it!