### PR TITLE
docs: Fix function names in controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,10 @@ Ember.Controller.extend({
   // your regular controller code
 
   actions: {
-    myStartAction: function(content) {
+    dragStartAction: function(content) {
      //Content is the same as the content parameter set above
     },
-    myEndAction: function(content) {
+    dragEndAction: function(content) {
       //Content is the same as the content parameter set above
     },
   }


### PR DESCRIPTION
I think the function names in the example controller are incorrect. This PR updates them to the correct values referenced in the [draggable object](https://github.com/mharris717/ember-drag-drop/pull/214/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R93).