### PR TITLE
DragOvering the DraggableObject from one SortableObjects to another not working properly. #212

### DIFF
--- a/addon/services/drag-coordinator.js
+++ b/addon/services/drag-coordinator.js
@@ -76,7 +76,7 @@ export default Service.extend({
   draggingOver(event, emberObject) {
     const currentOffsetItem = this.get('currentOffsetItem');
     const pos = this.relativeClientPosition(emberObject.element, event);
-    const hasSameSortingScope = this.get('currentDragItem.sortingScope') === emberObject.get('sortingScope');
+    const hasSameSortingScope = this.get('currentDragItem').sortingScope === emberObject.get('sortingScope');
     let moveDirections = [];
 
     if (!this.get('lastEvent')) {
@@ -102,7 +102,7 @@ export default Service.extend({
     this.set('lastEvent', event);
 
     if (!this.get('isMoving') && this.get('currentDragEvent')) {
-      if (event.target !== this.get('currentDragEvent').target) { //if not dragging over self
+      if (event.target !== this.get('currentDragEvent').target && hasSameSortingScope) { //if not dragging over self
         if (currentOffsetItem !== emberObject) {
           if (pos.py < 0.67 && moveDirections.indexOf('up') >= 0 ||
               pos.py > 0.33 && moveDirections.indexOf('down') >= 0 ||

--- a/addon/services/drag-coordinator.js
+++ b/addon/services/drag-coordinator.js
@@ -102,7 +102,7 @@ export default Service.extend({
     this.set('lastEvent', event);
 
     if (!this.get('isMoving') && this.get('currentDragEvent')) {
-      if (event.target !== this.get('currentDragEvent').target && hasSameSortingScope) { //if not dragging over self
+      if (event.target !== this.get('currentDragEvent').target) { //if not dragging over self
         if (currentOffsetItem !== emberObject) {
           if (pos.py < 0.67 && moveDirections.indexOf('up') >= 0 ||
               pos.py > 0.33 && moveDirections.indexOf('down') >= 0 ||

--- a/addon/services/drag-coordinator.js
+++ b/addon/services/drag-coordinator.js
@@ -76,7 +76,7 @@ export default Service.extend({
   draggingOver(event, emberObject) {
     const currentOffsetItem = this.get('currentOffsetItem');
     const pos = this.relativeClientPosition(emberObject.element, event);
-    const hasSameSortingScope = this.get('currentDragItem').sortingScope === emberObject.get('sortingScope');
+    const hasSameSortingScope = this.get('currentDragItem').get('sortingScope') === emberObject.get('sortingScope');
     let moveDirections = [];
 
     if (!this.get('lastEvent')) {


### PR DESCRIPTION
Hello,
When dragging the object and dragOvering to another list. It was added to the new list even without dropping the item. And not able to shift that item without dropping the currentDragItem. Then I need to drop the current item, drag and dragover the object again to shift the object.

The reason is,
const hasSameSortingScope = this. get('currentDragItem.sortingScope ') === emberObject.get('sortingScope');
this.get return undefined in this chain path.

sol:
const hasSameSortingScope = this. get('currentDragItem').sortingScope === emberObject.get('sortingScope');
or
const hasSameSortingScope = this.currentDragItem.sortingScope === emberObject.sortingScope;

Hopefully, it will not change other behaviors.